### PR TITLE
Added functionality, fixed Type 1 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 Talesweaver TEX Extractor <br />
 Image data stored in 3 version (5,6,7,8) and 4 type (0,1,2,3)  <br />
 Now full support only  <br />
-Ver:(5,6,7,8) Type:2 <br />
- 
-Incorrect Color (I don't know palette) <br />
-Ver:(5,6,7,8) Type:1  <br />
+Ver:(5,6,7,8) Type:2 (palettized)<br />
+Ver:(5,6,7,8) Type:1  (16-bit colour)<br />
 
 Incorrect Color (I don't know why!!!) <br />
 Ver:(5,6,7,8) Type:0 <br />

--- a/TEXView/DTXFile.cs
+++ b/TEXView/DTXFile.cs
@@ -88,10 +88,18 @@ namespace TEXView
             return _ret;
         }
 
-        public bool ReadFromStream(Stream _D2MStreamSource)
+        public bool ReadFromStream(Stream _D2MStreamSource, bool writeToFile = false, string filePath = "")
         {
             _DTXReader = new DTXReader(this);
-            bool _ret = _DTXReader.Open(_D2MStreamSource);
+            bool _ret = _DTXReader.Open(_D2MStreamSource, writeToFile, filePath);
+            _D2MStreamSource.Dispose();
+            return _ret;
+        }
+
+        public Stream ReadFromStreamAndDecompress(Stream _D2MStreamSource)
+        {
+            _DTXReader = new DTXReader(this);
+            Stream _ret = _DTXReader.Decompress(_D2MStreamSource);
             _D2MStreamSource.Dispose();
             return _ret;
         }

--- a/TEXView/DTXReader.cs
+++ b/TEXView/DTXReader.cs
@@ -150,7 +150,7 @@ namespace TEXView
         private bool BuildImage()
         {
             MemoryStream ms = null;
-            if (DTXFile.Header.ImgType != 3)
+            if (DTXFile.Header.ImgType != 1)
             {
                 ms = new MemoryStream(DTXFile.DataStorage);
             }
@@ -177,7 +177,7 @@ namespace TEXView
                     System.Drawing.Bitmap ImgP = new System.Drawing.Bitmap(_i.Info.Width, _i.Info.Height, PixelFormat.Format24bppRgb);
                     for (int ChkIdx = 0; ChkIdx < _i.Info.ChunkCount; ++ChkIdx)
                     {
-                        if (DTXFile.Header.ImgType != 3)
+                        if (DTXFile.Header.ImgType != 1)
                         {
                             ChunkInfo nChk = (ChunkInfo)_i.ChunkList[ChkIdx];
                             int _Row = nChk.Row;
@@ -235,7 +235,7 @@ namespace TEXView
             return true;
         }
 
-        public bool Open(Stream _stream)
+        public bool Open(Stream _stream, bool writeToFile = false, string filePath = "")
         {
             DTXFile.Header = new DTXHeader();
             DTXFile.ImgLists = new List<ImgInfo>();
@@ -246,7 +246,19 @@ namespace TEXView
             Int16 Hzip = _br.ReadInt16();
             MemoryStream _decompress;
             DecompressData(_stream, out _decompress);
+            
             _stream = _decompress;
+
+            if (writeToFile)
+            {
+                Stream dtxWriter = new FileStream(filePath, FileMode.Create,
+                                                             FileAccess.Write, FileShare.Write);
+                //dtxWriter.Write(_stream., 0, _stream.Length);
+                _stream.CopyTo(dtxWriter);
+                _stream.Position = 0;
+                dtxWriter.Flush();
+                dtxWriter.Dispose();
+            }
 
             Read<DTXHeader>(_stream, ref DTXFile.Header);
 
@@ -318,7 +330,7 @@ namespace TEXView
                     //!--This type all image as big image.
                     DTXFile.Header.ImgCount = 1;
                 }
-                else if (DTXFile.Header.ImgType == 3 )
+                else if (DTXFile.Header.ImgType == 1 )
                 {
                     for (int imgidx = 0; imgidx < DTXFile.Header.ImgCount; ++imgidx)
                     {
@@ -390,6 +402,21 @@ namespace TEXView
             }
            
             return true;
+        }
+
+        public Stream Decompress(Stream _stream) {
+
+            DTXFile.Header = new DTXHeader();
+            DTXFile.ImgLists = new List<ImgInfo>();
+            DTXFile.ImageDefineLists = new List<Object>();
+
+            BinaryReader _br = new BinaryReader(_stream);
+            //UInt32 _ZipSize = _br.ReadUInt32(); //!--Test
+            Int16 Hzip = _br.ReadInt16();
+            MemoryStream _decompress;
+            DecompressData(_stream, out _decompress);
+
+            return _decompress;
         }
     }
 }

--- a/TEXView/DTXReader.cs
+++ b/TEXView/DTXReader.cs
@@ -156,7 +156,7 @@ namespace TEXView
             }
 
             for (int imgidx = 0; imgidx < DTXFile.Header.ImgCount; ++imgidx)
-            {
+                              {
                 ImgInfo _i = DTXFile.ImgLists[imgidx];
 
                 if(_i.Info.Width == 0 || _i.Info.Height == 0 )
@@ -241,6 +241,7 @@ namespace TEXView
 
                         Bitmap bm = new Bitmap(_bp);
                         _i.Img = bm;
+                        _bp.Dispose();
                     }
                     else if (DTXFile.Header.ImgType != 3)
                     {
@@ -256,6 +257,7 @@ namespace TEXView
 
                         Bitmap bm = new Bitmap(_bp);
                         _i.Img = bm;
+                        _bp.Dispose();
                     }
                     else
                     {

--- a/TEXView/DTXReader.cs
+++ b/TEXView/DTXReader.cs
@@ -330,7 +330,7 @@ namespace TEXView
                     //!--This type all image as big image.
                     DTXFile.Header.ImgCount = 1;
                 }
-                else if (DTXFile.Header.ImgType == 1 )
+                else if (DTXFile.Header.ImgType == 3)
                 {
                     for (int imgidx = 0; imgidx < DTXFile.Header.ImgCount; ++imgidx)
                     {

--- a/TEXView/DTXReader.cs
+++ b/TEXView/DTXReader.cs
@@ -150,7 +150,7 @@ namespace TEXView
         private bool BuildImage()
         {
             MemoryStream ms = null;
-            if (DTXFile.Header.ImgType != 1)
+            if (DTXFile.Header.ImgType != 3)
             {
                 ms = new MemoryStream(DTXFile.DataStorage);
             }
@@ -177,7 +177,7 @@ namespace TEXView
                     System.Drawing.Bitmap ImgP = new System.Drawing.Bitmap(_i.Info.Width, _i.Info.Height, PixelFormat.Format24bppRgb);
                     for (int ChkIdx = 0; ChkIdx < _i.Info.ChunkCount; ++ChkIdx)
                     {
-                        if (DTXFile.Header.ImgType != 1)
+                        if (DTXFile.Header.ImgType != 3)
                         {
                             ChunkInfo nChk = (ChunkInfo)_i.ChunkList[ChkIdx];
                             int _Row = nChk.Row;
@@ -188,6 +188,19 @@ namespace TEXView
 
                             Raw.CopyTo(ImgD, _Row * _i.Info.Width + _Pos);
                         }
+                        /*else if (DTXFile.Header.ImgType == 1 && DTXFile.Header.Version != 8 && DTXFile.Header.Version != 7) {
+                            ChunkInfo nChk = (ChunkInfo)_i.ChunkList[ChkIdx];
+                            int _Row = nChk.Row;
+                            int _Pos = nChk.Pos;
+
+                            Byte[] Raw = new Byte[nChk.ChunkSize];
+                            //for (int i = 0; i < Raw.Length; i++) {
+                            //    Raw[i] = 0xC9;
+                            //}
+                            ReadBytes(ms, (uint)nChk.ChunkSize, ref Raw);
+
+                            Raw.CopyTo(ImgD, _Row * _i.Info.Width + _Pos);
+                        }*/
                         else
                         {
                             ChunkInfoT3 nChk = (ChunkInfoT3)_i.ChunkList[ChkIdx];

--- a/TEXView/Form1.Designer.cs
+++ b/TEXView/Form1.Designer.cs
@@ -29,34 +29,126 @@
         private void InitializeComponent()
         {
             this.button1 = new System.Windows.Forms.Button();
+            this.txtDestFolder = new System.Windows.Forms.TextBox();
+            this.btnDestBrowse = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.rbImagesSeparateFolder = new System.Windows.Forms.RadioButton();
+            this.rbImagesSingleFolder = new System.Windows.Forms.RadioButton();
+            this.rbDumpDTX = new System.Windows.Forms.RadioButton();
+            this.rbDumpDTXZipFiles = new System.Windows.Forms.RadioButton();
             this.SuspendLayout();
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(123, 35);
+            this.button1.Location = new System.Drawing.Point(113, 183);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.Size = new System.Drawing.Size(124, 23);
             this.button1.TabIndex = 0;
-            this.button1.Text = "Browse";
+            this.button1.Text = "Browse for TEX.DAT";
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // txtDestFolder
+            // 
+            this.txtDestFolder.Location = new System.Drawing.Point(12, 145);
+            this.txtDestFolder.Name = "txtDestFolder";
+            this.txtDestFolder.Size = new System.Drawing.Size(249, 20);
+            this.txtDestFolder.TabIndex = 1;
+            // 
+            // btnDestBrowse
+            // 
+            this.btnDestBrowse.Location = new System.Drawing.Point(267, 142);
+            this.btnDestBrowse.Name = "btnDestBrowse";
+            this.btnDestBrowse.Size = new System.Drawing.Size(54, 23);
+            this.btnDestBrowse.TabIndex = 2;
+            this.btnDestBrowse.Text = "Browse";
+            this.btnDestBrowse.UseVisualStyleBackColor = true;
+            this.btnDestBrowse.Click += new System.EventHandler(this.btnDestBrowse_Click);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(13, 126);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(95, 13);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "Output Destination";
+            // 
+            // rbImagesSeparateFolder
+            // 
+            this.rbImagesSeparateFolder.AutoSize = true;
+            this.rbImagesSeparateFolder.Location = new System.Drawing.Point(16, 13);
+            this.rbImagesSeparateFolder.Name = "rbImagesSeparateFolder";
+            this.rbImagesSeparateFolder.Size = new System.Drawing.Size(174, 17);
+            this.rbImagesSeparateFolder.TabIndex = 4;
+            this.rbImagesSeparateFolder.TabStop = true;
+            this.rbImagesSeparateFolder.Text = "Dump Images (separate folders)";
+            this.rbImagesSeparateFolder.UseVisualStyleBackColor = true;
+            // 
+            // rbImagesSingleFolder
+            // 
+            this.rbImagesSingleFolder.AutoSize = true;
+            this.rbImagesSingleFolder.Location = new System.Drawing.Point(16, 37);
+            this.rbImagesSingleFolder.Name = "rbImagesSingleFolder";
+            this.rbImagesSingleFolder.Size = new System.Drawing.Size(155, 17);
+            this.rbImagesSingleFolder.TabIndex = 5;
+            this.rbImagesSingleFolder.TabStop = true;
+            this.rbImagesSingleFolder.Text = "Dump Images (single folder)";
+            this.rbImagesSingleFolder.UseVisualStyleBackColor = true;
+            // 
+            // rbDumpDTX
+            // 
+            this.rbDumpDTX.AutoSize = true;
+            this.rbDumpDTX.Location = new System.Drawing.Point(16, 61);
+            this.rbDumpDTX.Name = "rbDumpDTX";
+            this.rbDumpDTX.Size = new System.Drawing.Size(102, 17);
+            this.rbDumpDTX.TabIndex = 6;
+            this.rbDumpDTX.TabStop = true;
+            this.rbDumpDTX.Text = "Dump DTX Files";
+            this.rbDumpDTX.UseVisualStyleBackColor = true;
+            // 
+            // rbDumpDTXZipFiles
+            // 
+            this.rbDumpDTXZipFiles.AutoSize = true;
+            this.rbDumpDTXZipFiles.Location = new System.Drawing.Point(16, 85);
+            this.rbDumpDTXZipFiles.Name = "rbDumpDTXZipFiles";
+            this.rbDumpDTXZipFiles.Size = new System.Drawing.Size(120, 17);
+            this.rbDumpDTXZipFiles.TabIndex = 7;
+            this.rbDumpDTXZipFiles.TabStop = true;
+            this.rbDumpDTXZipFiles.Text = "Dump DTX.Zip Files";
+            this.rbDumpDTXZipFiles.UseVisualStyleBackColor = true;
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(333, 117);
+            this.ClientSize = new System.Drawing.Size(333, 224);
+            this.Controls.Add(this.rbDumpDTXZipFiles);
+            this.Controls.Add(this.rbDumpDTX);
+            this.Controls.Add(this.rbImagesSingleFolder);
+            this.Controls.Add(this.rbImagesSeparateFolder);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.btnDestBrowse);
+            this.Controls.Add(this.txtDestFolder);
             this.Controls.Add(this.button1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Name = "Form1";
             this.Text = "TEX(Dat) Extractor 0.1 (Rattajin)";
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
 
         private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.TextBox txtDestFolder;
+        private System.Windows.Forms.Button btnDestBrowse;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.RadioButton rbImagesSeparateFolder;
+        private System.Windows.Forms.RadioButton rbImagesSingleFolder;
+        private System.Windows.Forms.RadioButton rbDumpDTX;
+        private System.Windows.Forms.RadioButton rbDumpDTXZipFiles;
     }
 }
 

--- a/TEXView/Form1.Designer.cs
+++ b/TEXView/Form1.Designer.cs
@@ -84,6 +84,7 @@
             this.rbImagesSeparateFolder.TabStop = true;
             this.rbImagesSeparateFolder.Text = "Dump Images (separate folders)";
             this.rbImagesSeparateFolder.UseVisualStyleBackColor = true;
+            this.rbImagesSeparateFolder.Click += new System.EventHandler(this.rbImagesSeparateFolder_Click);
             // 
             // rbImagesSingleFolder
             // 
@@ -95,6 +96,7 @@
             this.rbImagesSingleFolder.TabStop = true;
             this.rbImagesSingleFolder.Text = "Dump Images (single folder)";
             this.rbImagesSingleFolder.UseVisualStyleBackColor = true;
+            this.rbImagesSingleFolder.Click += new System.EventHandler(this.rbImagesSingleFolder_Click);
             // 
             // rbDumpDTX
             // 
@@ -106,6 +108,7 @@
             this.rbDumpDTX.TabStop = true;
             this.rbDumpDTX.Text = "Dump DTX Files";
             this.rbDumpDTX.UseVisualStyleBackColor = true;
+            this.rbDumpDTX.Click += new System.EventHandler(this.rbDumpDTX_Click);
             // 
             // rbDumpDTXZipFiles
             // 
@@ -117,6 +120,7 @@
             this.rbDumpDTXZipFiles.TabStop = true;
             this.rbDumpDTXZipFiles.Text = "Dump DTX.Zip Files";
             this.rbDumpDTXZipFiles.UseVisualStyleBackColor = true;
+            this.rbDumpDTXZipFiles.Click += new System.EventHandler(this.rbDumpDTXZipFiles_Click);
             // 
             // Form1
             // 

--- a/TEXView/Form1.cs
+++ b/TEXView/Form1.cs
@@ -23,6 +23,16 @@ namespace TEXView
 
         private void button1_Click(object sender, EventArgs e)
         {
+        //horrible and lazy error checking. Sorry.
+        if (txtDestFolder.Text == string.Empty || 
+              (!rbDumpDTX.Checked && !rbDumpDTXZipFiles.Checked && !rbImagesSeparateFolder.Checked && !rbImagesSingleFolder.Checked)) {
+                return;
+        }
+            string destFolderPath = txtDestFolder.Text;
+            bool dumpImagesSeparateFolders = rbImagesSeparateFolder.Checked;
+            bool dumpImagesSingleFolder = rbImagesSingleFolder.Checked;
+            bool dumpDTXFiles = rbDumpDTX.Checked;
+            bool dumpDTXZipFiles = rbDumpDTXZipFiles.Checked;
 
             Hashtable _hpacks = new Hashtable();
             OpenFileDialog _openDlg = new OpenFileDialog();
@@ -49,24 +59,99 @@ namespace TEXView
                     Stream _sf = (Stream)_hpacks[d.PackID];
                     _sf.Seek(d.Pos, SeekOrigin.Begin);
                     Byte[] _filedata = new Byte[d.CompressSize];
-                    _sf.Read(_filedata, 0, d.CompressSize);
+                    //_sf.Read(_filedata, 0, d.CompressSize);
+                    string DTXZipOutPath = destFolderPath + "\\DTXZipOut";
+                    
+                    int fullSize = d.CompressSize + 4;
+                    int uncompSize = d.UnCompressSize;
+                    _filedata = new Byte[fullSize];
+
+                    if (d.CompressSize > 0)
+                    {
+                        byte[] b = new byte[4];
+                        b[0] = (byte)(((uint)uncompSize) & 0xFF);
+                        b[1] = (byte)(((uint)uncompSize >> 8) & 0xFF);
+                        b[2] = (byte)(((uint)uncompSize >> 16) & 0xFF);
+                        b[3] = (byte)(((uint)uncompSize >> 24) & 0xFF);
+
+                        _filedata[0] = b[0];
+                        _filedata[1] = b[1];
+                        _filedata[2] = b[2];
+                        _filedata[3] = b[3];
+                        _sf.Read(_filedata, 4, d.CompressSize);
+
+                        if (dumpDTXZipFiles)
+                        {
+                            if (!Directory.Exists(DTXZipOutPath))
+                            {
+                                Directory.CreateDirectory(DTXZipOutPath);
+                            }
+                            Stream outStream = new FileStream(DTXZipOutPath + "\\" + _filenum.ToString("D4") + ".dtx.zip", FileMode.Create,
+                                                              FileAccess.Write, FileShare.Write);
+                            outStream.Write(_filedata, 0, d.CompressSize + 4);
+                            outStream.Flush();
+                            outStream.Dispose();
+                        }
+                        Console.WriteLine(_filenum++.ToString("D4"));
+                    }
+
+                    Byte[] _filedata2 = _filedata.Skip(4).ToArray();
+                    Byte[] _filedata3 = _filedata.Skip(4).ToArray();
                     DTXFile _f = new DTXFile();
 
-                    string _dirname = string.Format("\\DTX_{0}", _filenum++);
-                    string ImgDir = _directory  + _dirname;
-                    MemoryStream _mf = new MemoryStream(_filedata);
-                    if (_f.ReadFromStream(_mf))
+                    string _dirname = string.Format("\\DTX_{0}", _filenum);
+                    string ImgDir = destFolderPath + _dirname;
+                    
+                    MemoryStream _mf = new MemoryStream(_filedata2);
+                    MemoryStream _mf2 = new MemoryStream(_filedata3);
+
+                    string DTXOutPath = destFolderPath + "\\DTXOut";
+                    if (!Directory.Exists(DTXOutPath))
                     {
-                        if (!Directory.Exists(ImgDir))
+                        Directory.CreateDirectory(DTXOutPath);
+                    }
+                    DTXFile _dtxout = new DTXFile();
+                    Stream dtxOutStream = _dtxout.ReadFromStreamAndDecompress(_mf);
+                    Byte[] dtxBytes = new Byte[dtxOutStream.Length];
+                    dtxOutStream.Read(dtxBytes, 0, (int)dtxOutStream.Length);
+
+                    if (dumpDTXFiles)
+                    {
+                        Stream dtxWriter = new FileStream(DTXOutPath + "\\" + _filenum.ToString("D4") + ".dtx", FileMode.Create,
+                                                             FileAccess.Write, FileShare.Write);
+                        dtxWriter.Write(dtxBytes, 0, dtxBytes.Length);
+                        dtxWriter.Flush();
+                        dtxWriter.Dispose();
+                    }
+                    //Console.WriteLine(_filenum.ToString("D4") + ".dtx");
+
+                    if (dumpImagesSeparateFolders || dumpImagesSingleFolder) {
+                        if (_f.ReadFromStream(_mf2, true, DTXOutPath + "\\" + _filenum.ToString("D4") + ".dtx"))
                         {
-                            Directory.CreateDirectory(ImgDir);
+                            string SingleFolderOutPath = destFolderPath + "\\SingleFolderOutput";                            
+                            for (int imgidx = 0; imgidx < _f.ImgLists.Count; ++imgidx)
+                            {
+                                ImgInfo _i = _f.ImgLists[imgidx];
+                                if (dumpImagesSeparateFolders)
+                                {
+                                    if (!Directory.Exists(ImgDir))
+                                    {
+                                        Directory.CreateDirectory(ImgDir);
+                                    }
+                                    _i.Img.Save(ImgDir + string.Format("\\{0}.png", imgidx), ImageFormat.Png);
+                                }
+                                if (dumpImagesSingleFolder)
+                                {
+                                    if (!Directory.Exists(SingleFolderOutPath))
+                                    {
+                                        Directory.CreateDirectory(SingleFolderOutPath);
+                                    }
+                                    _i.Img.Save(SingleFolderOutPath + "\\" + _filenum.ToString("D4") + "-" + string.Format("{0}.png", imgidx), ImageFormat.Png);
+                                }
+                                _i.Img.Dispose();
+                            }
                         }
-                        for (int imgidx = 0; imgidx < _f.ImgLists.Count; ++imgidx)
-                        {
-                            ImgInfo _i = _f.ImgLists[imgidx];
-                            _i.Img.Save(ImgDir + string.Format("\\{0}.bmp", imgidx), ImageFormat.Bmp);
-                        }
-                        Console.WriteLine(string.Format("Filenum {0} Ver:{1} Type:{2}", _filenum,_f.Header.Version, _f.Header.ImgType));
+                        //Console.WriteLine(string.Format("Filenum {0} Ver:{1} Type:{2}", _filenum++,_f.Header.Version, _f.Header.ImgType));
                     }
                 }
                 while (_datsource.Position < _datsource.Length);
@@ -102,6 +187,21 @@ namespace TEXView
             //        }
             //    }
             //}
+        }
+
+        private void btnDestBrowse_Click(object sender, EventArgs e)
+        {
+            FolderBrowserDialog destSrc = new FolderBrowserDialog();
+            DialogResult destSrcResult = destSrc.ShowDialog();
+            if (destSrcResult == DialogResult.OK)
+            {
+                txtDestFolder.Text = destSrc.SelectedPath.ToString();
+            }
+            else
+            {
+                txtDestFolder.Text = String.Empty;
+            }
+            destSrc.Dispose();
         }
     }
 }

--- a/TEXView/Form1.cs
+++ b/TEXView/Form1.cs
@@ -86,13 +86,13 @@ namespace TEXView
                             {
                                 Directory.CreateDirectory(DTXZipOutPath);
                             }
-                            Stream outStream = new FileStream(DTXZipOutPath + "\\" + _filenum.ToString("D4") + ".dtx.zip", FileMode.Create,
+                            Stream outStream = new FileStream(DTXZipOutPath + "\\" + _filenum.ToString("D5") + ".dtx.zip", FileMode.Create,
                                                               FileAccess.Write, FileShare.Write);
                             outStream.Write(_filedata, 0, d.CompressSize + 4);
                             outStream.Flush();
                             outStream.Dispose();
                         }
-                        Console.WriteLine(_filenum.ToString("D4"));
+                        Console.WriteLine(_filenum.ToString("D5"));
                     }
 
                     Byte[] _filedata2 = _filedata.Skip(4).ToArray();
@@ -117,7 +117,7 @@ namespace TEXView
 
                     if (dumpDTXFiles)
                     {
-                        Stream dtxWriter = new FileStream(DTXOutPath + "\\" + _filenum.ToString("D4") + ".dtx", FileMode.Create,
+                        Stream dtxWriter = new FileStream(DTXOutPath + "\\" + _filenum.ToString("D5") + ".dtx", FileMode.Create,
                                                              FileAccess.Write, FileShare.Write);
                         dtxWriter.Write(dtxBytes, 0, dtxBytes.Length);
                         dtxWriter.Flush();
@@ -126,7 +126,7 @@ namespace TEXView
                     //Console.WriteLine(_filenum.ToString("D4") + ".dtx");
 
                     if (dumpImagesSeparateFolders || dumpImagesSingleFolder) {
-                        if (_f.ReadFromStream(_mf2, true, DTXOutPath + "\\" + _filenum.ToString("D4") + ".dtx"))
+                        if (_f.ReadFromStream(_mf2))
                         {
                             string SingleFolderOutPath = destFolderPath + "\\SingleFolderOutput";                            
                             for (int imgidx = 0; imgidx < _f.ImgLists.Count; ++imgidx)
@@ -146,11 +146,13 @@ namespace TEXView
                                     {
                                         Directory.CreateDirectory(SingleFolderOutPath);
                                     }
-                                    _i.Img.Save(SingleFolderOutPath + "\\" + _filenum.ToString("D4") + "-" + string.Format("{0}.png", imgidx), ImageFormat.Png);
+                                    _i.Img.Save(SingleFolderOutPath + "\\" + _filenum.ToString("D5") + "-" + string.Format("{0}.png", imgidx), ImageFormat.Png);
                                 }
                                 _i.Img.Dispose();
+                                
                             }
                         }
+                        _f = new DTXFile();
                         //Console.WriteLine(string.Format("Filenum {0} Ver:{1} Type:{2}", _filenum++,_f.Header.Version, _f.Header.ImgType));
                     }
                     _filenum++;

--- a/TEXView/Form1.cs
+++ b/TEXView/Form1.cs
@@ -92,7 +92,7 @@ namespace TEXView
                             outStream.Flush();
                             outStream.Dispose();
                         }
-                        Console.WriteLine(_filenum++.ToString("D4"));
+                        Console.WriteLine(_filenum.ToString("D4"));
                     }
 
                     Byte[] _filedata2 = _filedata.Skip(4).ToArray();
@@ -153,6 +153,7 @@ namespace TEXView
                         }
                         //Console.WriteLine(string.Format("Filenum {0} Ver:{1} Type:{2}", _filenum++,_f.Header.Version, _f.Header.ImgType));
                     }
+                    _filenum++;
                 }
                 while (_datsource.Position < _datsource.Length);
 

--- a/TEXView/Form1.cs
+++ b/TEXView/Form1.cs
@@ -114,7 +114,7 @@ namespace TEXView
                     Stream dtxOutStream = _dtxout.ReadFromStreamAndDecompress(_mf);
                     Byte[] dtxBytes = new Byte[dtxOutStream.Length];
                     dtxOutStream.Read(dtxBytes, 0, (int)dtxOutStream.Length);
-
+                    dtxOutStream.Dispose();
                     if (dumpDTXFiles)
                     {
                         Stream dtxWriter = new FileStream(DTXOutPath + "\\" + _filenum.ToString("D5") + ".dtx", FileMode.Create,
@@ -149,13 +149,14 @@ namespace TEXView
                                     _i.Img.Save(SingleFolderOutPath + "\\" + _filenum.ToString("D5") + "-" + string.Format("{0}.png", imgidx), ImageFormat.Png);
                                 }
                                 _i.Img.Dispose();
-                                
                             }
+                            _f.ImgLists.Clear();
                         }
-                        _f = new DTXFile();
                         //Console.WriteLine(string.Format("Filenum {0} Ver:{1} Type:{2}", _filenum++,_f.Header.Version, _f.Header.ImgType));
                     }
                     _filenum++;
+                    _mf.Dispose();
+                    _mf2.Dispose();
                 }
                 while (_datsource.Position < _datsource.Length);
 
@@ -205,6 +206,34 @@ namespace TEXView
                 txtDestFolder.Text = String.Empty;
             }
             destSrc.Dispose();
+        }
+
+        private void rbImagesSeparateFolder_Click(object sender, EventArgs e)
+        {
+            rbDumpDTX.Checked = false;
+            rbDumpDTXZipFiles.Checked = false;
+            rbImagesSingleFolder.Checked = false;
+        }
+
+        private void rbImagesSingleFolder_Click(object sender, EventArgs e)
+        {
+            rbDumpDTX.Checked = false;
+            rbDumpDTXZipFiles.Checked = false;
+            rbImagesSeparateFolder.Checked = false;
+        }
+
+        private void rbDumpDTX_Click(object sender, EventArgs e)
+        {
+            rbDumpDTXZipFiles.Checked = false;
+            rbImagesSeparateFolder.Checked = false;
+            rbImagesSingleFolder.Checked = false;
+        }
+
+        private void rbDumpDTXZipFiles_Click(object sender, EventArgs e)
+        {
+            rbDumpDTX.Checked = false;
+            rbImagesSeparateFolder.Checked = false;
+            rbImagesSingleFolder.Checked = false;
         }
     }
 }


### PR DESCRIPTION
I know this is an old project, but I've done some work on it regardless. I added the ability to choose to dump dtx files, dtx.zip files, images in separate directories as was default, and images all in a single directory. It's set so that the TEX.DAT file cannot be picked until a format and destination directory are selected.

I've also fixed up the output of Type 1 images. There was no palette because they were 16-bit images. This means the vast majority of graphics will now dump correctly, even with current versions of the game.

It should be noted that there is a memory leak when exporting images that likely would not have been much of a problem with older versions of the game and having significantly fewer files to process. I have been unable to pin the issue down.